### PR TITLE
Add openpyxl dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 streamlit
 pandas
+openpyxl
 python-barcode
 Pillow
 reportlab


### PR DESCRIPTION
## Summary
- include openpyxl in requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_686fc0e8c428832a8774284acfb90335